### PR TITLE
CI: bump CI actions to latest versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: 3.12
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Install the project
         run: uv sync
       - name: Build


### PR DESCRIPTION
* Upgrade actions/checkout to v6 for improved functionality and security.
* Update astral-sh/setup-uv to a specific commit for consistency in builds.